### PR TITLE
"Fix text wrapping on mobile"

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,11 +42,11 @@ export default function Home() {
     <div className="min-h-full mb-24 w-full overflow-visible">
       <Toaster />
       <div className="flex flex-col h-[80vh] sm:h-[100svh] relative overflow-visible justify-center ">
-          <div className="mx-auto flex mb-4 sm:mb-8 sm:flex sm:justify-center">
-            <Link href="survey" className="relative rounded-full px-3 py-1 text-xs sm:text-sm leading-6 text-gray-600 ring-1 ring-gray-900/10 hover:ring-gray-900/20">
-              We are leading a <span className="text-orange underline">survey</span> to better understand your needs.{' '}
-            </Link>
-          </div>
+        <div className="mx-auto flex mb-4 sm:mb-8 sm:flex sm:justify-center">
+          <Link href="survey" className="relative rounded-full px-2 py-1 text-xs sm:text-sm text-center leading-6 text-gray-600 ring-1 ring-gray-900/10 hover:ring-gray-900/20">
+            Your feedback matters. Take our <span className="text-orange underline">survey</span>.
+          </Link>
+        </div>
         <h1 className={cn("text-5xl font-medium text-center", whyte.className)}>
           IS YOUR APP
           <strong className="text-orange"> SECURE?</strong>


### PR DESCRIPTION
The text on the homepage was wrapping on mobile devices, making it difficult to read. This pull request fixes the issue by shortening the text to prevent wrapping.